### PR TITLE
Fix to the computation of start and end of a selection

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -2,7 +2,7 @@ import esbuild from "esbuild";
 import process from "process";
 import builtins from "builtin-modules";
 import fs from "fs";
-import sass from "node-sass";
+import * as sass from 'sass'
 
 const banner =
 	`/*

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	"dependencies": {
 		"@codemirror/language": "^6.10.1",
 		"@lezer/generator": "^1.7.0",
-		"node-sass": "^9.0.0",
+		"sass": "^1.94.2",
 		"ts-node": "^10.9.2"
 	}
 }

--- a/src/color/TextColorFunctions.ts
+++ b/src/color/TextColorFunctions.ts
@@ -38,10 +38,10 @@ export function applyColor(tColor: TextColor, editor: Editor) {
 
 	let selections = editor.listSelections();
 	selections.forEach(element => {
-		let anchorpos = element.anchor.line + element.anchor.ch;
-		let headpos = element.head.line + element.head.ch;
-		let start = anchorpos < headpos ? element.anchor : element.head;
-		let end = anchorpos < headpos ? element.head : element.anchor;
+		const anchorOffset = editor.posToOffset(element.anchor);
+		const headOffset = editor.posToOffset(element.head);
+		let start =  anchorOffset < headOffset ? element.anchor : element.head;
+		let end = anchorOffset < headOffset ? element.head : element.anchor;
 
 		let selected = editor.getRange(start, end);
 		let coloredText = `${prefix}${selected}${suffix}`;


### PR DESCRIPTION
The start and end of a selection is obtained by comparing the [line + ch] of the anchor and the head. When the selection is between the end of a line and the beginning of another, it fails to give the correct order. This fixes it by comparing the offsets of the anchor and the head instead.