### PR TITLE
Align behavior of highlighting to Obsidian defaults

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -2,7 +2,7 @@ import esbuild from "esbuild";
 import process from "process";
 import builtins from "builtin-modules";
 import fs from "fs";
-import sass from "node-sass";
+import * as sass from 'sass'
 
 const banner =
 	`/*

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	"dependencies": {
 		"@codemirror/language": "^6.10.1",
 		"@lezer/generator": "^1.7.0",
-		"node-sass": "^9.0.0",
+		"sass": "^1.94.2",
 		"ts-node": "^10.9.2"
 	}
 }

--- a/src/color/TextColorFunctions.ts
+++ b/src/color/TextColorFunctions.ts
@@ -51,10 +51,19 @@ export function applyColor(tColor: TextColor, editor: Editor) {
 		const coloredLines = selectedLines.join('\n');
 		editor.replaceRange(coloredLines, start, end);
 
-		start.ch += prefix.length;
-		end.ch += prefix.length;
-
-		editor.setSelection(start,end);
+		// Set selection to be the text within the exterior fences
+		// Ignore empty lines at the beginning and end
+		// If all lines are empty, put cursor at the end of selection
+		const nonEmpty = (element) => element.length > 0;
+		if (!selectedLines.some(nonEmpty))
+			editor.setCursor(end);
+		else {
+			const firstNonEmptyLine = selectedLines.findIndex(nonEmpty);
+			const lastNonEmptyLine = selectedLines.findLastIndex(nonEmpty);
+			const beginSelection = {line: start.line + firstNonEmptyLine, ch:(firstNonEmptyLine == 0) ? start.ch + prefix.length : prefix.length};
+			const endSelection = {line: start.line + lastNonEmptyLine, ch:(lastNonEmptyLine == selectedLines.length) ? end.ch + prefix.length : selectedLines[lastNonEmptyLine].length - suffix.length};
+			editor.setSelection(beginSelection, endSelection);
+		}
 	});
 
 	// TODO check if there already is some coloring applied somewhere near.

--- a/src/color/TextColorFunctions.ts
+++ b/src/color/TextColorFunctions.ts
@@ -38,10 +38,10 @@ export function applyColor(tColor: TextColor, editor: Editor) {
 
 	let selections = editor.listSelections();
 	selections.forEach(element => {
-		let anchorpos = element.anchor.line + element.anchor.ch;
-		let headpos = element.head.line + element.head.ch;
-		let start = anchorpos < headpos ? element.anchor : element.head;
-		let end = anchorpos < headpos ? element.head : element.anchor;
+		const anchorOffset = editor.posToOffset(element.anchor);
+		const headOffset = editor.posToOffset(element.head);
+		let start =  anchorOffset < headOffset ? element.anchor : element.head;
+		let end = anchorOffset < headOffset ? element.head : element.anchor;
 
 		let selected = editor.getRange(start, end);
 		let coloredText = `${prefix}${selected}${suffix}`;

--- a/src/color/TextColorFunctions.ts
+++ b/src/color/TextColorFunctions.ts
@@ -43,23 +43,18 @@ export function applyColor(tColor: TextColor, editor: Editor) {
 		let start =  anchorOffset < headOffset ? element.anchor : element.head;
 		let end = anchorOffset < headOffset ? element.head : element.anchor;
 
-		let selected = editor.getRange(start, end);
-		let coloredText = `${prefix}${selected}${suffix}`;
-
-
-
-
-		editor.replaceRange(coloredText, start, end);
-
-		// move cursor one item to the right.
-		// could not find a way to query for last possible position, so trycatch is needed.
-		try {
-			let pos = editor.getCursor();
-			pos.ch = pos.ch + 1;
-			editor.setCursor(pos);
-		} catch {
-			return;
+		const selected = editor.getRange(start, end);
+		let selectedLines = selected.split('\n');
+		for (let i=0; i < selectedLines.length; i++) {
+			if (selectedLines[i]) selectedLines[i] = prefix + selectedLines[i] + suffix; 
 		}
+		const coloredLines = selectedLines.join('\n');
+		editor.replaceRange(coloredLines, start, end);
+
+		start.ch += prefix.length;
+		end.ch += prefix.length;
+
+		editor.setSelection(start,end);
 	});
 
 	// TODO check if there already is some coloring applied somewhere near.

--- a/src/color/TextColorFunctions.ts
+++ b/src/color/TextColorFunctions.ts
@@ -38,18 +38,19 @@ export function applyColor(tColor: TextColor, editor: Editor) {
 
 	let selections = editor.listSelections();
 	selections.forEach(element => {
+		// Compute start and end of selection from anchor and head
 		const anchorOffset = editor.posToOffset(element.anchor);
 		const headOffset = editor.posToOffset(element.head);
 		let start =  anchorOffset < headOffset ? element.anchor : element.head;
 		let end = anchorOffset < headOffset ? element.head : element.anchor;
 
+		// Add fences to all nonempty lines of the selection
 		const selected = editor.getRange(start, end);
 		let selectedLines = selected.split('\n');
 		for (let i=0; i < selectedLines.length; i++) {
 			if (selectedLines[i]) selectedLines[i] = prefix + selectedLines[i] + suffix; 
 		}
-		const coloredLines = selectedLines.join('\n');
-		editor.replaceRange(coloredLines, start, end);
+		editor.replaceRange(selectedLines.join('\n'), start, end);
 
 		// Set selection to be the text within the exterior fences
 		// Ignore empty lines at the beginning and end

--- a/src/color/TextColorFunctions.ts
+++ b/src/color/TextColorFunctions.ts
@@ -62,7 +62,7 @@ export function applyColor(tColor: TextColor, editor: Editor) {
 			const firstNonEmptyLine = selectedLines.findIndex(nonEmpty);
 			const lastNonEmptyLine = selectedLines.findLastIndex(nonEmpty);
 			const beginSelection = {line: start.line + firstNonEmptyLine, ch:(firstNonEmptyLine == 0) ? start.ch + prefix.length : prefix.length};
-			const endSelection = {line: start.line + lastNonEmptyLine, ch:(lastNonEmptyLine == selectedLines.length) ? end.ch + prefix.length : selectedLines[lastNonEmptyLine].length - suffix.length};
+			const endSelection = {line: start.line + lastNonEmptyLine, ch:(lastNonEmptyLine == selectedLines.length-1) ? end.ch + prefix.length : selectedLines[lastNonEmptyLine].length - suffix.length};
 			editor.setSelection(beginSelection, endSelection);
 		}
 	});


### PR DESCRIPTION
In Obsidian, when applying bold, italics or highlights to a selection, then fences are added to each nonempty line of the selection, and the text selected afterwards is the one in-between the exterior fences.

The proposed change here aligns the behavior of the coloring to the one in Obsidian. This has the added benefit of fixing an issue, which is that coloring currently doesn't work when there are empty lines in the selection.